### PR TITLE
Use `process.exitCode` instead of `process.exit(code)`

### DIFF
--- a/examples/testAll.js
+++ b/examples/testAll.js
@@ -17,5 +17,5 @@ for (const file of glob.sync('examples/*/tests/**/*.js')) {
 }
 
 if (failures) {
-  process.exit(1)
+  process.exitCode = 1
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -259,10 +259,10 @@ function runNonInteractiveMode (testModulePath) {
       if (errors.length) {
         if (errors.every(e => e.__prescriptPending)) {
           console.log(chalk.bold.yellow('Test pending'), formattedTimeTaken)
-          process.exit(2)
+          process.exitCode = 2
         } else {
           console.log(chalk.bold.red('Test failed'), formattedTimeTaken)
-          process.exit(1)
+          process.exitCode = 1
         }
       } else {
         console.log(chalk.bold.green('すばらしい!'), formattedTimeTaken)


### PR DESCRIPTION
This encourages the test writers to clean up their tests properly