### PR TITLE
runto first of children with parent step number

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -172,7 +172,12 @@ function runDevelopmentMode (testModulePath) {
         console.log(chalk.red('Error: step number is not exists in test'))
         return
       }
-      yield runTestWhileConditionMet(() => !(tester.getCurrentStepNumber() === String(args.stepNumber)))
+      const matchCondition = () => {
+        const currentStep = tester.getCurrentStepNumber()
+        const targetStep = String(args.stepNumber)
+        return (currentStep === targetStep || currentStep === `${targetStep}.1`)
+      }
+      yield runTestWhileConditionMet(() => !matchCondition())
     }), callback)
   })
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -175,7 +175,7 @@ function runDevelopmentMode (testModulePath) {
       const matchCondition = () => {
         const currentStep = tester.getCurrentStepNumber()
         const targetStep = String(args.stepNumber)
-        return (currentStep === targetStep || currentStep === `${targetStep}.1`)
+        return `${currentStep}.`.startsWith(`${targetStep}.`)
       }
       yield runTestWhileConditionMet(() => !matchCondition())
     }), callback)


### PR DESCRIPTION
```
Step 1. [A]
Step 2. [B]
Step 2.1. [C]
Step 2.2. [D]
Step 2.3. [E]
Step 2.4. [F]
Step 3. [G]
Step 4. [H]
Step 4.1. [I]
Step 4.2. [J]
Step 5. [K]
Step 5.1. [L]
Step 6. [M]
```
`prescript> runto 4`

Now, it can stop at `4.1`.

