### PR TITLE
v0.5555555 - Implicit pending steps and independent steps

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -3,7 +3,7 @@
 Import `prescript` to access its APIs.
 
 ```js
-const { test, to, action, defer, pending, named } = require('prescript')
+const { test, to, action, defer, pending, independent } = require('prescript')
 ```
 
 ## `test`
@@ -40,15 +40,14 @@ action`Fill in username`(async (state, context) => { /* Action here */ })
 Creates an **action step.** The function passed to `action()` will be called
 with these arguments:
 
-* **state** - The state object. In the beginning of the test, it is empty. Add
+- **state** - The state object. In the beginning of the test, it is empty. Add
   things to this object to share state between steps and have it persisted
   between reloads.
-* **context** - The context object contains:
-  * `log(...)` - Logs a message to the console. Use this instead of
+- **context** - The context object contains:
+  - `log(...)` - Logs a message to the console. Use this instead of
     `console.log()` so that it doesn’t mess up console output.
-  * `attach(name, buffer, mimeType)` — Attachs some binary output. For
-    example, screenshots, raw API response. This will get written to the Allure
-    report.
+  - `attach(name, buffer, mimeType)` — Attachs some binary output. For example,
+    screenshots, raw API response. This will get written to the Allure report.
 
 ## `defer`
 
@@ -86,12 +85,14 @@ pending()
 ```
 <!-- prettier-ignore-end -->
 
-Defines a **pending step.** When a pending step is run, it marks the test as pending.
+Defines a **pending step.** When a pending step is run, it marks the test as
+pending.
 
 - When running in **development mode**, this causes the test to **pause**.
 - When run in **non-interactive mode**, prescript will **exit with code 2**.
 
-See more example how to use a pending step [here](https://prescript.netlify.com/guide/writing-tests.html#pending-steps).
+See more example how to use a pending step
+[here](https://prescript.netlify.com/guide/writing-tests.html#pending-steps).
 
 ## `getCurrentState()`
 
@@ -112,3 +113,19 @@ requiring users to pass the `state` object all the way from the action.
 This can make writing tests more convenient, but treat this like a global
 variable — it introduces an _implicit_ runtime dependency from the caller to
 prescript’s internal state.
+
+## `independent(() => { ... })`
+
+Steps directly inside this block will be run independently. For example, in the
+following code, actions A, B, and C would always be run even if preceding
+actions failed. However, action D will not be run if any previous actions
+failed.
+
+```js
+independent(() => {
+  action`A`(...)
+  action`B`(...)
+  action`C`(...)
+})
+action`D`(...)
+```

--- a/examples/independent/tests/Independent-test.fail
+++ b/examples/independent/tests/Independent-test.fail
@@ -1,0 +1,19 @@
+const { test, action, independent } = require('../../..')
+
+independent(() => {
+  test('Test 1', () => {
+    action('Test 1 action', () => {
+      throw new Error('a')
+    })
+  })
+
+  test('Test 2', () => {
+    action('Test 2 action', () => {})
+  })
+
+  test('Test 3', () => {
+    action('Test 3 action', () => {
+      throw new Error('b')
+    })
+  })
+})

--- a/examples/pending/tests/Implicit-pending-composite-step.js
+++ b/examples/pending/tests/Implicit-pending-composite-step.js
@@ -1,0 +1,3 @@
+// This is a pending test.
+// Pending tests exit with code=2 and should handle this exit code appropriately.
+require('../../..').to`Implement later`()

--- a/examples/pending/tests/Implicit-pending-test.js
+++ b/examples/pending/tests/Implicit-pending-test.js
@@ -1,0 +1,3 @@
+// This is a pending test.
+// Pending tests exit with code=2 and should handle this exit code appropriately.
+require('../../..').action`Do this`()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prescript",
-  "version": "0.555555.0",
+  "version": "0.5555555.0-1",
   "description": "Object-oriented acceptance test tool",
   "main": "./lib/singletonApi.js",
   "typings": "./lib/singletonApi.d.ts",

--- a/src/createTestIterator.ts
+++ b/src/createTestIterator.ts
@@ -83,7 +83,7 @@ function createStepper(
               visitor.visitDeferNode(child)
             }
             deferredSteps.push(child)
-          } else if (child.cleanup || stillOk) {
+          } else if (child.cleanup || child.independent || stillOk) {
             stillOk = (yield* walk(child)) && stillOk
           }
         }

--- a/src/singletonApi.ts
+++ b/src/singletonApi.ts
@@ -97,6 +97,13 @@ export function pending(): void {
   getInstance().pending()
 }
 
+/**
+ * Marks the steps inside as independent
+ */
+export function independent<X>(f: () => X): X {
+  return getInstance().independent(f)
+}
+
 /** @deprecated Use `to()` instead. */
 export function step<X>(name: StepDefName, f: () => X): X
 

--- a/src/singletonApi.ts
+++ b/src/singletonApi.ts
@@ -34,7 +34,7 @@ export function to<X>(name: string, f: () => X): X
 export function to(
   nameParts: TemplateStringsArray,
   ...substitutions: any[]
-): <X>(f: () => X) => X
+): <X>(f?: () => X) => X
 
 /**
  * Creates a Compound Test Step, which can contain child steps.
@@ -54,7 +54,7 @@ export function action(name: string, f: ActionFunction): void
 export function action(
   nameParts: TemplateStringsArray,
   ...substitutions: any[]
-): (f: ActionFunction) => void
+): (f?: ActionFunction) => void
 
 /**
  * Makes the enclosing `step()` an Action Step.
@@ -80,7 +80,7 @@ export function defer(name: string, f: ActionFunction): void
 export function defer(
   nameParts: TemplateStringsArray,
   ...substitutions: any[]
-): (f: ActionFunction) => void
+): (f?: ActionFunction) => void
 
 /**
  * Creates a Deferred Action Step, for, e.g., cleaning up resources.

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface IStep {
   children?: IStep[]
   creator?: string
   definition?: string
+  independent?: boolean
 
   action?: ActionFunction
   actionDefinition?: string
@@ -78,6 +79,8 @@ export interface IPrescriptAPI {
   cleanup<X>(name: StepDefName, f: () => X): X
 
   onFinish(f: () => void): void
+
+  independent<X>(f: () => X): X
 
   // This is only in IPrescriptAPI
   use(f: (api: IPrescriptAPI) => void): void


### PR DESCRIPTION
- **Implicit pending steps** allows you to write pending step by simply use `to` or `action` without the implementation:

  ```js
  // Without a callback, this test will be marked as pending.
  action`Click on the button`()
  ```

- **Independent steps** allows you to write independent assertions that will be run independently.

  ```js
  // Without `independent`, if "Verify name" fails, the whole test would be aborted.
  // That means email and address will not be verified.
  // With `independent`, even if "Verify name" fails,
  // we will still verify email and address,
  // but after that block the test will abort (Follow-up stuff will not be executed).
  independent(() => {
    action`Verify name`(...)
    action`Verify email`(...)
    action`Verify address`(...)
  })
  action`Follow-up stuff`(...)
  ```
